### PR TITLE
SpecFuzz pass: Don't instrument MFENCE instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Build a sample vulnerable program:
 ```bash
 $ cd example
 $ make sf
-clang-sf -fsanitize=address -O1 main.c -c -o main.sf.o
+clang-sf -fsanitize=address -O1 demo.c -c -o main.sf.o
 clang-sf -fsanitize=address -O1 sizes.c -c -o sizes.sf.o
 clang-sf -fsanitize=address -O1 main.sf.o sizes.sf.o -o demo-sf
 ```
@@ -48,7 +48,7 @@ $ ./demo-sf 11
 [SF], 1, 0x123, 0x456, 0, 0x789
 r = 0
 ```
-Here, the line `[SF], 1, 0x123, 0x456, 0, 0x52b519` means that SpecFuzz detected that the instruction
+Here, the line `[SF], 1, 0x123, 0x456, 0, 0x789` means that SpecFuzz detected that the instruction
 at address `0x123` tried to access an invalid address `0x456`, and the speculation was triggered
 by a misprediction of a branch at the address `0x789`.
 ## Fuzz it

--- a/src/SpecFuzzPass.cpp
+++ b/src/SpecFuzzPass.cpp
@@ -588,6 +588,8 @@ auto X86SpecFuzzPass::visitWrite(MachineInstr &MI, MachineBasicBlock &Parent) ->
     // Pushes are a special case as the address is always in RSP
     if (isPush(MI.getOpcode()))
         return visitPush(MI, Parent);
+    if(MI.getOpcode() == X86::MFENCE)
+        return false;
 
     LLVM_DEBUG(dbgs() << "Instrumenting store: " << MI);
     DebugLoc Loc = MI.getDebugLoc();


### PR DESCRIPTION
Before this change, the SpecFuzz pass would fail to compile code that used
MFENCEs because it is treated as a write instruction with no memory operands by
LLVM.

This patch skips instrumenting MFENCEs. In the future, it might make sense to
have SpecFuzz respond in some way to MFENCEs, but for now, skipping them is a
decent workaround.

Tested by using the test case here: https://github.com/OleksiiOleksenko/SpecFuzz/issues/18, before the change it crashes, after the change it compiles