### PR TITLE
README.md: Fix errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Build a sample vulnerable program:
 ```bash
 $ cd example
 $ make sf
-clang-sf -fsanitize=address -O1 main.c -c -o main.sf.o
+clang-sf -fsanitize=address -O1 demo.c -c -o main.sf.o
 clang-sf -fsanitize=address -O1 sizes.c -c -o sizes.sf.o
 clang-sf -fsanitize=address -O1 main.sf.o sizes.sf.o -o demo-sf
 ```
@@ -48,7 +48,7 @@ $ ./demo-sf 11
 [SF], 1, 0x123, 0x456, 0, 0x789
 r = 0
 ```
-Here, the line `[SF], 1, 0x123, 0x456, 0, 0x52b519` means that SpecFuzz detected that the instruction
+Here, the line `[SF], 1, 0x123, 0x456, 0, 0x789` means that SpecFuzz detected that the instruction
 at address `0x123` tried to access an invalid address `0x456`, and the speculation was triggered
 by a misprediction of a branch at the address `0x789`.
 ## Fuzz it


### PR DESCRIPTION
* The main file in the examples folder is named demo.c rather than main.c.

* The second edit is a typo (compare the address from the example output to the address in the explanation of that output.)